### PR TITLE
Disambiguate flags from dashes in passwords

### DIFF
--- a/i3/config
+++ b/i3/config
@@ -277,7 +277,7 @@ bindsym $mod+d exec rofi -show run
 bindsym $mod+Shift+d exec rofi -show window
 
 # Paste from clipboard like a human being types
-bindsym --release $mod+p exec sleep 1 && xdotool type --clearmodifiers `xclip -selection c -out`
+bindsym --release $mod+p exec sleep 1 && xdotool type --clearmodifiers -- `xclip -selection c -out`
 
 bindsym $mod+Shift+x exec --no-startup-id xautolock -locknow
 bindsym $mod+Shift+s exec --no-startup-id setxkbmap -option caps:swapescape


### PR DESCRIPTION
Any password that starts with - will be interpreted as a flag by xdotool and could lead to arbitrary actions. -- makes this explicit and fixes the issue. 

Yep! The first password I tried actually started with a - :D